### PR TITLE
feature/options-return-button: Menu functionality optimized.

### DIFF
--- a/scenes/Menu/LevelView.tscn
+++ b/scenes/Menu/LevelView.tscn
@@ -55,6 +55,7 @@ margin_bottom = 126.0
 theme = ExtResource( 1 )
 text = "Back"
 script = ExtResource( 3 )
+menus = "StartGame"
 
 [node name="FadeIn" parent="." instance=ExtResource( 4 )]
 visible = false

--- a/scenes/Menu/LoadGame.tscn
+++ b/scenes/Menu/LoadGame.tscn
@@ -3,3 +3,4 @@
 [ext_resource path="res://scenes/Menu/MenuScene.tscn" type="PackedScene" id=1]
 
 [node name="LoadGame" instance=ExtResource( 1 )]
+menus = "LoadGame"

--- a/scenes/Menu/MenuScene.tscn
+++ b/scenes/Menu/MenuScene.tscn
@@ -18,10 +18,10 @@ margin_top = 330.0
 margin_right = 674.0
 margin_bottom = 389.0
 
-[node name="Button" type="Button" parent="CenterContainer/VBoxContainer"]
+[node name="BackButton" type="Button" parent="CenterContainer/VBoxContainer"]
 margin_right = 68.0
 margin_bottom = 59.0
 theme = ExtResource( 3 )
 text = "Back"
 
-[connection signal="pressed" from="CenterContainer/VBoxContainer/Button" to="." method="_on_Button_pressed"]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/BackButton" to="." method="_on_BackButton_pressed"]

--- a/scenes/Menu/Options.tscn
+++ b/scenes/Menu/Options.tscn
@@ -3,3 +3,4 @@
 [ext_resource path="res://scenes/Menu/MenuScene.tscn" type="PackedScene" id=1]
 
 [node name="Options" instance=ExtResource( 1 )]
+menus = "Options"

--- a/src/scripts/Globle.gd
+++ b/src/scripts/Globle.gd
@@ -35,6 +35,8 @@ var vendor_open 	 	= false
 var vendor_active 	 	= false
 var melee_attack 		= false
 
+var menu_to_return 		= "none"
+
 # Not sure if we need this instance_node
 func instance_node(node,location,parent):
 	var node_instance=node.instance()

--- a/src/scripts/Menu/MainMenu.gd
+++ b/src/scripts/Menu/MainMenu.gd
@@ -1,11 +1,22 @@
 extends Control
 
-onready var index_button = $VBoxContainer/CenterRow/Buttons/NewGameButton
+onready var new_game_button  = $VBoxContainer/CenterRow/Buttons/NewGameButton
+onready var load_game_button = $VBoxContainer/CenterRow/Buttons/LoadGameButton
+onready var options_button   = $VBoxContainer/CenterRow/Buttons/OptionsButton
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	get_tree().paused = false
-	index_button.grab_focus()
+
+	# Set the active button.
+	match Globle.menu_to_return:
+		"LoadGame":
+			load_game_button.grab_focus()
+		"Options":
+			options_button.grab_focus()
+		_:
+			new_game_button.grab_focus()
+
 	for button in $VBoxContainer/CenterRow/Buttons.get_children():
 		button.connect("pressed", self, "_on_Button_pressed", [button.scene_to_load])
 

--- a/src/scripts/Menu/Options.gd
+++ b/src/scripts/Menu/Options.gd
@@ -3,10 +3,7 @@ extends Control
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	$CancelContainer/CancelButton.grab_focus()
-	
+
 # Return to the menu.
 func _on_CancelButton_pressed():
-	var main_menu = load("res://src/scripts/Menu/MainMenu.gd")
-	
-	main_menu.button_focus()
 	get_tree().current_scene.remove_child(self)

--- a/src/scripts/Menu/ReturnMainMenu.gd
+++ b/src/scripts/Menu/ReturnMainMenu.gd
@@ -1,10 +1,22 @@
 extends Control
 
+onready var index_button = $CenterContainer/VBoxContainer/BackButton
+
+export(String, "StartGame", "LoadGame", "Options") var menus
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var index_button = self
-	index_button.grab_focus()
+	index_button.grab_focus() if index_button != null else self.grab_focus()
 
 # When gets pressed.
 func _on_BackButton_pressed():
+	match menus:
+		"LoadGame":
+			Globle.menu_to_return = "LoadGame"
+		"Options":
+			Globle.menu_to_return = "Options"
+		"StartGame":
+			Globle.menu_to_return = "StartGame"
+		_:
+			Globle.menu_to_return = "StartGame"
 	get_tree().change_scene("res://scenes/Menu/MainMenu.tscn")

--- a/src/scripts/Player/PauseMenuContainer.gd
+++ b/src/scripts/Player/PauseMenuContainer.gd
@@ -25,4 +25,5 @@ func _on_ReturnToGameButton_pressed():
 
 # Returns to the main menu.
 func _on_ReturnToMainMenuButton_pressed():
+	Globle.menu_to_return = "StartGame"
 	get_tree().change_scene("res://scenes/Menu/MainMenu.tscn")


### PR DESCRIPTION
### [Options return buttons](https://trello.com/c/bkEru2xP/50-options-and-load-return-buttons)

![image](https://user-images.githubusercontent.com/33086486/209666064-6e6c0adc-bb16-4b38-88ce-d46991235a03.png)

**Description of the issue:**
When you were visiting the menus in the prior version, the button specific for a sub-menu never focused that button. 

**How to test:**
In this PR, this logic was implemented. If you now go to either `OPTIONS` or `LOAD GAME` view, you see that the return button is focused on both. If you return from either of those to the main menu, you will see that the button focused is the button specific for that sub-menu. And when you quit the game, going back to the main menu, you will see that the `START GAME` is the one highlighted.