### PR TITLE
hotfix/missing-mesh-library: Fixed the missing mesh library issue.

### DIFF
--- a/scenes/Levels/test_level.tscn
+++ b/scenes/Levels/test_level.tscn
@@ -132,7 +132,7 @@ skeleton = NodePath("../..")
 shape = SubResource( 12 )
 
 [node name="GridMap" type="GridMap" parent="."]
-mesh_library = ExtResource( 7 )
+mesh_library = ExtResource( 12 )
 collision_layer = 3
 collision_mask = 3
 data = {


### PR DESCRIPTION
### Missing mesh library issue.
Added the mesh library to the grid map in `test_level.tscn`.